### PR TITLE
Fixes error in NativeMethods SendMessage extern declaration

### DIFF
--- a/BotSuite/BotSuite.csproj
+++ b/BotSuite/BotSuite.csproj
@@ -92,7 +92,6 @@
     <Compile Include="Recognition\Character\MagicMatchSticks.cs" />
     <Compile Include="Recognition\Character\OCR.cs" />
     <Compile Include="ScreenShot.cs" />
-    <Compile Include="Settings.cs" />
     <Compile Include="Utility.cs" />
     <Compile Include="NativeMethods.cs" />
     <Compile Include="Window.cs" />

--- a/BotSuite/NativeMethods.cs
+++ b/BotSuite/NativeMethods.cs
@@ -157,6 +157,7 @@ namespace BotSuite
 
         [DllImport("user32.dll", CharSet = CharSet.Auto)]
         internal static extern IntPtr SendMessage(IntPtr hWnd, UInt32 Msg, IntPtr wParam, IntPtr lParam);
+        [DllImport("user32.dll", CharSet = CharSet.Auto)]
         internal static extern bool SendMessage(IntPtr hWnd, int wMsg, uint wParam, uint lParam);
         [DllImport("user32.dll")]
         internal static extern uint keybd_event(byte bVk, byte bScan, int dwFlags, int dwExtraInfo);


### PR DESCRIPTION
The SendMessage method causes a "no implementation" error without an
extra DllImport tag:

Additional information: Could not load type 'BotSuite.NativeMethods'
from assembly 'BotSuite, Version=1.0.0.2, Culture=neutral,
PublicKeyToken=null' because the method 'SendMessage' has no
implementation (no RVA).

Also, updated project file to reflect the removal of Settings.cs
