### PR TITLE
Fix the cropping behaviour of ImageData.CreateBitmap

### DIFF
--- a/BotSuite/ImageLibrary/ImageData.cs
+++ b/BotSuite/ImageLibrary/ImageData.cs
@@ -201,7 +201,8 @@ namespace BotSuite.ImageLibrary
 
             ReturnBitmap.UnlockBits(bmpData);
 
-            // Then, we crop the generated rectangle to the new size:
+            // Then, if necessary, we crop the generated rectangle to the new size:
+            if (!(L == 0 && T == 0 && W == Width && H == Height)) ;
             Rectangle cropRect = new Rectangle(L, T, W, H);
             Bitmap target = new Bitmap(cropRect.Width, cropRect.Height);
 


### PR DESCRIPTION
CreateBitmap takes arguments which allow you to crop an image to retain only a segment. However the LockBits copy command was not doing this: it was copying all the bytes over to the new file until the new file was full, resulting in a skewed image. Also, it ignored the bitmap format, resulting in messed up colours with 32bit bmps.
I've rewritten the CreateBitmap method to first create a bitmap of the data stored in ImageData and then crop it using graphics libraries.
